### PR TITLE
MagicBloom.fx flicker bug fix

### DIFF
--- a/FFXIV/GShade/MalkovichPhoto-real.ini
+++ b/FFXIV/GShade/MalkovichPhoto-real.ini
@@ -483,7 +483,6 @@ fLUT_AmountLuma=1.000000
 [MagicBloom.fx]
 f2Adapt_Clip=0.000000,1.000000
 fAdapt_Sensitivity=1.000000
-fAdapt_Speed=1.000000
 fBloom_Intensity=1.065000
 fBloom_Threshold=2.000000
 fDirt_Intensity=0.000000


### PR DESCRIPTION
In some extreme light conditions, mostly at night with a flickering light source nearby lighting up multiple differently colored moving surfaces ie. light reflections lighting up a character (mostly when close up but can happen from further away), the bloom adaptation from MagicBloom.fx will go haywire due to the other settings being pretty aggressive and it'll start making the screen flicker anywhere from "quite a lot" to "a LOT and violently" (pure white screen to very dark and so on).   

Restoring that value to a more sensible value like the default 0.100 instead of the current 1.000 completely fixes that issue for no visible difference since this only affects the speed at which it changes not the change itself.  

The whole preset being taxing already due to being made for screenshots mostly, I don't see a reason for it to require instantaneous transitions for its effects since your framerate will be heavily cut anyways on most systems.